### PR TITLE
Class/package renaming to improve ux

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,32 +1,16 @@
 # python-jerakia
 
-## POC use example
+A Python client library for Jerakia server (https://jerakia.io)
+
+## Usage example
+
+With a Jerakia server running on localhost, do
 
 ```
-from jerakia import Jerakia
-
-metadata = dict( hostname = 'agent1.localdomain')
-token = 'ansible:4142672cd08d4dbb9eb3c1234567e46c1b85b20d75501ebc319c17a62dae636c1509b8bea1a66b3e'
-content_type = 'json'
-jerakia = Jerakia()
-
-r1_json = jerakia.lookup(key='ntp_timezone', namespace='ntp', content_type=content_type, token=token)
-r2_json = jerakia.lookup(key='ntp_timezone', namespace='ntp', content_type=content_type, token=token, metadata_dict=metadata)
-r3_json = jerakia.lookup(namespace='ntp', content_type=content_type, token=token)
-r4_json = jerakia.lookup(namespace='ntp', content_type=content_type, token=token, metadata_dict=metadata)
-r1_msgpack = jerakia.lookup(key='ntp_timezone', namespace='ntp', token=token)
-r2_msgpack = jerakia.lookup(key='ntp_timezone', namespace='ntp', token=token, metadata_dict=metadata)
-r3_msgpack = jerakia.lookup(namespace='ntp', token=token)
-r4_msgpack = jerakia.lookup(namespace='ntp', token=token, metadata_dict=metadata)
-
-print('r1_json result: {}'.format(r1_json))
-print('r1_json result: {}'.format(r2_json))
-print('r1_json result: {}'.format(r3_json))
-print('r1_json result: {}'.format(r4_json))
-
-print('r1_msgpack result: {}'.format(r1_msgpack))
-print('r2_msgpack result: {}'.format(r2_msgpack))
-print('r3_msgpack result: {}'.format(r3_msgpack))
-print('r4_msgpack result: {}'.format(r4_msgpack))
+python
+import jerakia
+token = 'dev:ac4093fec97c6d52f3b419db9b744d214d7428b0e0f75f2d98b8016df5b79dd819743583c047f47f'
+client = jerakia.Client(token=token)
+client.lookup(key='test',namespace='common')
 ```
 

--- a/jerakia/__init__.py
+++ b/jerakia/__init__.py
@@ -1,0 +1,3 @@
+
+from jerakia.client import Client
+

--- a/jerakia/__init__.py
+++ b/jerakia/__init__.py
@@ -1,3 +1,1 @@
-
 from jerakia.client import Client
-

--- a/jerakia/client.py
+++ b/jerakia/client.py
@@ -17,7 +17,7 @@ class Error(Exception):
     pass
 
 
-class JerakiaError(Error):
+class ClientError(Error):
     """Exception raised for errors in the Jerakia lib.
 
     Attributes:
@@ -28,7 +28,7 @@ class JerakiaError(Error):
         self.message = message
 
 
-class Jerakia(object):
+class Client(object):
     """Constructor."""
     def __init__(self, token, protocol='http', host='localhost', port=9843,
                  version=1):
@@ -45,7 +45,7 @@ class Jerakia(object):
             with open(configfile, "r") as filename:
                 config = yaml.load(filename)
         else:
-            raise JerakiaError("""Unable to find configuration file
+            raise ClientError("""Unable to find configuration file
                     {}""".format(configfile))
         return cls(**config)
 
@@ -102,5 +102,5 @@ class Jerakia(object):
         elif response.headers['content-type'] == self._content_type['msgpack']:
             return msgpack.unpackb(response.content)
         else:
-            raise JerakiaError("""Unkown content-type header recieved from jerakia
+            raise ClientError("""Unkown content-type header recieved from jerakia
             server: {}""".format(response.headers['content-type']))

--- a/jerakia/render.py
+++ b/jerakia/render.py
@@ -5,7 +5,7 @@ lib for rendering jinja templates using Jerakia lookups
 import sys
 import os
 from jinja2 import Environment, FileSystemLoader, Template
-from .jerakia import Jerakia,JerakiaError
+from .client import Client,ClientError
 from jinja2.ext import Extension
 
 jerakia = None

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup,find_packages
 
 setup(
     name='python-jerakia',
-    version='0.5.0',
+    version='0.7.2',
     packages=find_packages(),
     include_package_data=True,
     description='Python client library for Jerakia (https://jerakia.io)',

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,11 @@
 from setuptools import setup,find_packages
 
 setup(
-    name='jerakia',
-    version='0.4.0',
+    name='python-jerakia',
+    version='0.5.0',
     packages=find_packages(),
     include_package_data=True,
-    description='Jerakia',
+    description='Python client library for Jerakia (https://jerakia.io)',
     author='Jon Ander Novella',
     install_requires=[
         'requests>=2.0',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup,find_packages
 
 setup(
     name='python-jerakia',
-    version='0.7.2',
+    version='0.5.0',
     packages=find_packages(),
     include_package_data=True,
     description='Python client library for Jerakia (https://jerakia.io)',

--- a/tests/test_jerakia.py
+++ b/tests/test_jerakia.py
@@ -6,9 +6,10 @@ import unittest
 import mock
 import msgpack
 import jerakia
+from jerakia import render
 
 
-class TestJerakia(unittest.TestCase):
+class TestClient(unittest.TestCase):
 
     def setUp(self):
         self.test_dir = tempfile.mkdtemp()
@@ -122,7 +123,7 @@ class TestJerakia(unittest.TestCase):
 
         fields = {'it': 'common/test'}
         if 'it' in fields:
-            test_out = render(template_path=config_file_path, jerakia_instance=instance, data=fields)
+            test_out = render.render(template_path=config_file_path, jerakia_instance=instance, data=fields)
             self.assertIsNotNone(test_out)
             expected_test_out = '{' + "fieldA: 'sesame'" + ', ' + "fieldB: test" + '}'+ '\n'
             self.assertEqual(test_out, expected_test_out)

--- a/tests/test_jerakia.py
+++ b/tests/test_jerakia.py
@@ -5,8 +5,8 @@ import yaml
 import unittest
 import mock
 import msgpack
-from jerakia.jerakia import Jerakia
-from jerakia.render import render
+import jerakia
+
 
 class TestJerakia(unittest.TestCase):
 
@@ -36,7 +36,7 @@ class TestJerakia(unittest.TestCase):
         shutil.rmtree(self.test_dir)
 
     def test_default_config(self):
-        instance = Jerakia(self.token)
+        instance = jerakia.Client(self.token)
         self.assertIsNotNone(instance.config)
         for key in self.default_config.keys():
             self.assertEqual(instance.config[key], self.default_config[key])
@@ -46,7 +46,7 @@ class TestJerakia(unittest.TestCase):
         with open(config_file_path, 'w') as outfile:
             yaml.dump(self.file_config, outfile, default_flow_style=False)
 
-        instance = Jerakia.fromfile(config_file_path)
+        instance = jerakia.Client.fromfile(config_file_path)
         self.assertIsNotNone(instance.config)
         for key in self.default_config.keys():
             self.assertEqual(instance.config[key], self.file_config[key])
@@ -66,12 +66,12 @@ class TestJerakia(unittest.TestCase):
 
         return MockResponseJson({"found": "true","payload": "sesame"}, 200,'application/json')
 
-    @mock.patch('jerakia.jerakia.requests.get', side_effect=mocked_requests_get_json)
+    @mock.patch('jerakia.client.requests.get', side_effect=mocked_requests_get_json)
     def test_lookup_json(self,mock_lookup):
         """
         Test getting same dict response as expected from lookup using JSON
         """
-        instance = Jerakia(token=self.token)
+        instance = jerakia.Client(token=self.token)
         expected_dict = {
             "found": "true",
             "payload": "sesame"
@@ -95,12 +95,12 @@ class TestJerakia(unittest.TestCase):
 
         return MockResponseMsgpack(msgpack.packb({"found": "true","payload": "sesame"}, use_bin_type=True), 200,'application/x-msgpack')
 
-    @mock.patch('jerakia.jerakia.requests.get', side_effect=mocked_requests_get_msgpack)
+    @mock.patch('jerakia.client.requests.get', side_effect=mocked_requests_get_msgpack)
     def test_lookup_msgpack(self,mock_lookup):
         """
         Test getting same dict response as expected from lookup using JSON
         """
-        instance = Jerakia(token=self.token)
+        instance = jerakia.Client(token=self.token)
         expected_dict = {
             "found": "true",
             "payload": "sesame"
@@ -109,7 +109,7 @@ class TestJerakia(unittest.TestCase):
         # Check the contents of the response
         self.assertEqual(response_dict, expected_dict)
 
-    @mock.patch('jerakia.jerakia.requests.get', side_effect=mocked_requests_get_json)
+    @mock.patch('jerakia.client.requests.get', side_effect=mocked_requests_get_json)
     def test_render_json(self,mock_lookup):
         """
         Test render occurs successfully
@@ -118,7 +118,7 @@ class TestJerakia(unittest.TestCase):
         with open(config_file_path, 'w') as outfile:
             yaml.dump(self.render_file, outfile, default_flow_style=True)
 
-        instance = Jerakia(token=self.token)
+        instance = jerakia.Client(token=self.token)
 
         fields = {'it': 'common/test'}
         if 'it' in fields:


### PR DESCRIPTION
This improves developer UX and aligns with the Ruby and Golang libs, now you can

```python
import jerakia
c = jerakia.Client(token=token)
```
which is a considerable improvement in usability.

Updated README with this, updated version to 0.5.0